### PR TITLE
return transport address along with node name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ test-full:
 	 go test ./... -cover
 
 build:
-	gox -output "./bin/elastic-brain-surgeon_{{.OS}}_{{.Arch}}" -os "linux darwin" -arch "amd64 386"
+	@GOOS=linux go build -o bin/brain

--- a/clusterstatus/clusterstatus.go
+++ b/clusterstatus/clusterstatus.go
@@ -89,6 +89,7 @@ func getClusterState(address string) (ClusterState, error) {
 	address = normalizeAddress(address)
 	statusEndpoint := address + clusterStatusEndpoint
 	resp, err := makeHttpCall(statusEndpoint)
+	defer resp.Body.Close()
 	if err != nil {
 		return ClusterState{}, errors.New("could not connect to node")
 		log.Println("could not connect to node")
@@ -114,6 +115,7 @@ func getNodeStatus(address string) (NodeStatus, error) {
 	address = normalizeAddress(address)
 	statusEndpoint := address + nodeStatusEndpoint
 	resp, err := makeHttpCall(statusEndpoint)
+	defer resp.Body.Close()
 	if err != nil {
 		return NodeStatus{}, errors.New("could not connect to node")
 		log.Println("could not connect to node")

--- a/clusterstatus/clusterstatus.go
+++ b/clusterstatus/clusterstatus.go
@@ -14,7 +14,7 @@ import (
 const clusterStatusEndpoint = "/_cluster/state/nodes,master_node"
 const nodeStatusEndpoint = "/"
 
-var httpTimeout = time.Second * 1
+var httpTimeout = time.Second * 5
 
 // ClusterState is structure to keep response from /_cluster/state API call
 type ClusterState struct {

--- a/clusterstatus/clusterstatus.go
+++ b/clusterstatus/clusterstatus.go
@@ -16,11 +16,14 @@ const nodeStatusEndpoint = "/"
 
 var httpTimeout = time.Second * 1
 
+// ClusterState is structure to keep response from /_cluster/state API call
 type ClusterState struct {
 	MasterNode  string          `json:"master_node"`
 	ClusterName string          `json:"cluster_name"`
 	Nodes       map[string]Node `json:"nodes"`
 }
+
+// Node is structure to keep response about nodes in ClusterState API call
 type Node struct {
 	Name             string `json:"name"`
 	TransportAddress string `json:"transport_address"`
@@ -29,11 +32,13 @@ type Node struct {
 	} `json:"attributes"`
 }
 
+// NodeStatus is structure to keep response from node status API call
 type NodeStatus struct {
 	Status int    `json:"status"`
 	Name   string `json:"name"`
 }
 
+// ElasticsearchNode gathers information on Elasticsearch Node
 type ElasticsearchNode struct {
 	Name           string
 	Status         int
@@ -42,6 +47,7 @@ type ElasticsearchNode struct {
 	ErrorFetching  bool
 }
 
+// CheckForSplitBrain checks if there is more then one leader in the cluster
 func CheckForSplitBrain(nodes []ElasticsearchNode) bool {
 	for i := 1; i < len(nodes); i++ {
 		if nodes[i].MasterNode != nodes[i-1].MasterNode {
@@ -51,6 +57,8 @@ func CheckForSplitBrain(nodes []ElasticsearchNode) bool {
 	return false
 }
 
+// FetchNodes connects to group of nodes that it receives as a parameter and
+// gathers information about cluster topology
 func FetchNodes(esAddresses []string) ([]ElasticsearchNode, []ElasticsearchNode) {
 	nodesSuccessfull := make([]ElasticsearchNode, 0, len(esAddresses))
 	nodesFailed := make([]ElasticsearchNode, 0, len(esAddresses))
@@ -88,24 +96,24 @@ func asyncFetchNode(node string, nodesChan chan ElasticsearchNode) {
 func getClusterState(address string) (ClusterState, error) {
 	address = normalizeAddress(address)
 	statusEndpoint := address + clusterStatusEndpoint
-	resp, err := makeHttpCall(statusEndpoint)
+	resp, err := makeHTTPCall(statusEndpoint)
 	defer resp.Body.Close()
 	if err != nil {
-		return ClusterState{}, errors.New("could not connect to node")
 		log.Println("could not connect to node")
+		return ClusterState{}, errors.New("could not connect to node")
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusInternalServerError {
-		return ClusterState{}, errors.New("node has failed")
 		log.Println("node has failed")
+		return ClusterState{}, errors.New("node has failed")
 	}
 	var cs ClusterState
 	json.Unmarshal(body, &cs)
 	return cs, nil
 }
 
-func makeHttpCall(endpoint string) (*http.Response, error) {
+func makeHTTPCall(endpoint string) (*http.Response, error) {
 	var client = &http.Client{Timeout: httpTimeout}
 	resp, err := client.Get(endpoint)
 	return resp, err
@@ -114,27 +122,28 @@ func makeHttpCall(endpoint string) (*http.Response, error) {
 func getNodeStatus(address string) (NodeStatus, error) {
 	address = normalizeAddress(address)
 	statusEndpoint := address + nodeStatusEndpoint
-	resp, err := makeHttpCall(statusEndpoint)
+	resp, err := makeHTTPCall(statusEndpoint)
 	defer resp.Body.Close()
 	if err != nil {
-		return NodeStatus{}, errors.New("could not connect to node")
 		log.Println("could not connect to node")
+		return NodeStatus{}, errors.New("could not connect to node")
 	}
 	if resp.StatusCode == http.StatusInternalServerError {
-		return NodeStatus{}, errors.New("node has failed")
 		log.Println("node has failed")
+		return NodeStatus{}, errors.New("node has failed")
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return NodeStatus{}, errors.New(fmt.Sprintf("error reading body: %v", err))
-		log.Println("error reading body: %v", err)
+		log.Printf("error reading body: %v\n", err)
+		return NodeStatus{}, fmt.Errorf("error reading body: %v", err)
 	}
 	var ns NodeStatus
 	json.Unmarshal(body, &ns)
 	return ns, nil
 }
 
+// PrintMasterNodes prints all master nodes along with their children
 func PrintMasterNodes(ms map[string][]ElasticsearchNode) {
 	for master, nodes := range ms {
 		fmt.Printf("master: %s \n", master)
@@ -144,6 +153,7 @@ func PrintMasterNodes(ms map[string][]ElasticsearchNode) {
 	}
 }
 
+// PrintFailures prints nodes which we failed to connect to
 func PrintFailures(failures []ElasticsearchNode) {
 	fmt.Println("Failed connecting to:")
 	for _, failure := range failures {
@@ -151,6 +161,7 @@ func PrintFailures(failures []ElasticsearchNode) {
 	}
 }
 
+// GatherMasters retruns a map with all master nodes along with their children
 func GatherMasters(nodes []ElasticsearchNode) map[string][]ElasticsearchNode {
 	mappedMasters := make(map[string][]ElasticsearchNode)
 	for _, node := range nodes {
@@ -161,6 +172,7 @@ func GatherMasters(nodes []ElasticsearchNode) map[string][]ElasticsearchNode {
 	return mappedMasters
 }
 
+// AmIMaster checks if given Elasticseach address is a leader of the cluster
 func AmIMaster(myAddress string) (bool, error) {
 	nodeStatus, gNerr := getNodeStatus(myAddress)
 	clusterStatus, gCerr := getClusterState(myAddress)
@@ -186,10 +198,9 @@ func gatherFailures(nodes []ElasticsearchNode) []string {
 
 func normalizeAddress(address string) string {
 	httpPrefix := "http://"
-	startsWithHttp := strings.HasPrefix(address, httpPrefix)
-	if startsWithHttp {
+	startsWithHTTP := strings.HasPrefix(address, httpPrefix)
+	if startsWithHTTP {
 		return address
-	} else {
-		return (httpPrefix + address)
 	}
+	return (httpPrefix + address)
 }

--- a/clusterstatus/clusterstatus.go
+++ b/clusterstatus/clusterstatus.go
@@ -108,11 +108,11 @@ func getClusterState(address string) (ClusterState, error) {
 	address = normalizeAddress(address)
 	statusEndpoint := address + clusterStatusEndpoint
 	resp, err := makeHTTPCall(statusEndpoint)
-	// defer resp.Body.Close()
 	if err != nil {
 		log.Println("could not connect to node")
 		return ClusterState{}, errors.New("could not connect to node")
 	}
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode == http.StatusInternalServerError {
 		log.Println("node has failed")
@@ -133,11 +133,11 @@ func getNodeStatus(address string) (NodeStatus, error) {
 	address = normalizeAddress(address)
 	statusEndpoint := address + nodeStatusEndpoint
 	resp, err := makeHTTPCall(statusEndpoint)
-	defer resp.Body.Close()
 	if err != nil {
 		log.Println("could not connect to node")
 		return NodeStatus{}, errors.New("could not connect to node")
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusInternalServerError {
 		log.Println("node has failed")
 		return NodeStatus{}, errors.New("node has failed")

--- a/clusterstatus/clusterstatus_test.go
+++ b/clusterstatus/clusterstatus_test.go
@@ -72,13 +72,13 @@ const nodeClusterResponse = `{
   }
 }`
 
-var brokenCluster []ElasticsearchNode = []ElasticsearchNode{
+var brokenCluster = []ElasticsearchNode{
 	ElasticsearchNode{"Node1", 200, "Node1", 2, false},
 	ElasticsearchNode{"Node2", 200, "Node1", 2, false},
 	ElasticsearchNode{"Node3", 200, "Node3", 2, false},
 }
 
-var healthyCluster []ElasticsearchNode = []ElasticsearchNode{
+var healthyCluster = []ElasticsearchNode{
 	ElasticsearchNode{"Node1", 200, "Node1", 3, false},
 	ElasticsearchNode{"Node2", 200, "Node1", 3, false},
 	ElasticsearchNode{"Node3", 200, "Node1", 3, false},

--- a/clusterstatus/clusterstatus_test.go
+++ b/clusterstatus/clusterstatus_test.go
@@ -73,15 +73,15 @@ const nodeClusterResponse = `{
 }`
 
 var brokenCluster = []ElasticsearchNode{
-	ElasticsearchNode{"Node1", 200, "Node1", 2, false},
-	ElasticsearchNode{"Node2", 200, "Node1", 2, false},
-	ElasticsearchNode{"Node3", 200, "Node3", 2, false},
+	ElasticsearchNode{"Node1", "inet[/10.0.0.1:9300]", 200, "Node1", 2, false},
+	ElasticsearchNode{"Node2", "inet[/10.0.0.2:9300]", 200, "Node1", 2, false},
+	ElasticsearchNode{"Node3", "inet[/10.0.0.3:9300]", 200, "Node3", 2, false},
 }
 
 var healthyCluster = []ElasticsearchNode{
-	ElasticsearchNode{"Node1", 200, "Node1", 3, false},
-	ElasticsearchNode{"Node2", 200, "Node1", 3, false},
-	ElasticsearchNode{"Node3", 200, "Node1", 3, false},
+	ElasticsearchNode{"Node1", "inet[/10.0.0.1:9300]", 200, "Node1", 3, false},
+	ElasticsearchNode{"Node2", "inet[/10.0.0.2:9300]", 200, "Node1", 3, false},
+	ElasticsearchNode{"Node3", "inet[/10.0.0.3:9300]", 200, "Node1", 3, false},
 }
 
 func TestCheckForSplitBrainWhenSplitBrain(t *testing.T) {
@@ -97,6 +97,27 @@ func TestCheckForSplitBrainWhenNoSplitBrain(t *testing.T) {
 	splitBrain := CheckForSplitBrain(brokenCluster)
 	if expectedSplitBrainResult != splitBrain {
 		t.Errorf("Split brain not detected. Expected %v. Got %v", expectedSplitBrainResult, splitBrain)
+	}
+}
+
+func TestFetchNodesArguments(t *testing.T) {
+	expectedNode := ElasticsearchNode{"Node1", "inet[/10.0.0.1:9300]", 200, "Node1", 2, false}
+	node1 := mockNodeServer(node1StatusResposnse, nodeClusterResponse)
+	defer node1.Close()
+	nodesSuccessfull, _ := FetchNodes([]string{node1.URL})
+	fmt.Println(nodesSuccessfull)
+	node := nodesSuccessfull[0]
+	if node.Name != expectedNode.Name {
+		t.Errorf("Node name mismatch. Expected '%s', but got %v",
+			expectedNode.Name, node.Name)
+	}
+	if node.IPAddress != expectedNode.IPAddress {
+		t.Errorf("Node ip address mismatch. Expected '%s', but got %v",
+			expectedNode.IPAddress, node.IPAddress)
+	}
+	if node.Status != expectedNode.Status {
+		t.Errorf("Node status mismatch. Expected '%d', but got %v",
+			expectedNode.Status, node.Status)
 	}
 }
 
@@ -164,10 +185,10 @@ func TestGatherMasters(t *testing.T) {
 	const expectedMasterNodesAmount = 2
 	const expectedNodesCountGood = 3
 	const expectedNodesCountBad = 1
-	node1 := ElasticsearchNode{"Node1", 200, "Node1", 2, false}
-	node2 := ElasticsearchNode{"Node2", 200, "Node1", 2, false}
-	node3 := ElasticsearchNode{"Node3", 200, "Node1", 2, false}
-	node4 := ElasticsearchNode{"Node4", 200, "Node4", 2, false}
+	node1 := ElasticsearchNode{"Node1", "[inet[/10.0.0.1:9300]", 200, "Node1", 2, false}
+	node2 := ElasticsearchNode{"Node2", "[inet[/10.0.0.2:9300]", 200, "Node1", 2, false}
+	node3 := ElasticsearchNode{"Node3", "[inet[/10.0.0.3:9300]", 200, "Node1", 2, false}
+	node4 := ElasticsearchNode{"Node4", "[inet[/10.0.0.4:9300]", 200, "Node4", 2, false}
 	nodes := []ElasticsearchNode{node1, node2, node3, node4}
 	masterNodes := GatherMasters(nodes)
 	if masterNodesAmount := len(masterNodes); masterNodesAmount != expectedMasterNodesAmount {

--- a/clusterstatus/clusterstatus_test.go
+++ b/clusterstatus/clusterstatus_test.go
@@ -248,7 +248,7 @@ func mockNodeServerFailing() *httptest.Server {
 
 func mockNodeServerTimeout() *httptest.Server {
 	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(2 * time.Second)
+		time.Sleep(6 * time.Second)
 		fmt.Fprintln(w, "`{}`")
 	}))
 	return node

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mateuszzawisza/elastic-brain-surgeon/clusterstatus"
 )
 
-const Version = "0.0.2"
+const Version = "0.0.3"
 
 var esAddresses addresses
 var strict bool


### PR DESCRIPTION
Improved output

```
Everything is ok
master: elasticsearch-cluster-c80a0dd2
  node 0: elasticsearch-cluster-c80a0dd2 - inet[/172.10.1.1:9300] [master]
  node 1: elasticsearch-cluster-1e93c2eb - inet[/172.10.1.2:9300] [node]
  node 2: elasticsearch-cluster-23831040 - inet[/172.10.3.4:9300] [node]
  node 3: elasticsearch-cluster-07fbfad7 - inet[/172.10.1.4:9300] [node]
```